### PR TITLE
remove redundant import

### DIFF
--- a/provenance/_config.py
+++ b/provenance/_config.py
@@ -5,11 +5,6 @@ import provenance.repos as r
 import copy
 import toolz as t
 
-try:
-    import provenance.sftp as sftp
-except ImportError:
-    print('To use the sftp blobstore install Paramiko')
-
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
You'll notice [here](https://github.com/mmb90/provenance/commit/6718addd24dc1c2bf367be6b857b62c06402758a#diff-afeffa6737113ee76e96929d897b113cR8) that I forgot to erase the first import in lieu of the second one.