### PR TITLE
fix bug when you try to use sftp without paramiko

### DIFF
--- a/provenance/_config.py
+++ b/provenance/_config.py
@@ -44,8 +44,9 @@ try:
 
 except ImportError as e:
     class SFTPStore(object):
-        def __init__(*args, **kargs):
-            raise(e)
+        _err = e
+        def __init__(self, *args, **kargs):
+            raise(self._err)
 
     BLOBSTORE_TYPES['sftp'] = SFTPStore
 

--- a/provenance/sftp/__init__.py
+++ b/provenance/sftp/__init__.py
@@ -27,6 +27,7 @@ class SFTPStore(bs.BaseBlobStore):
             read=read, write=write, read_through_write=read_through_write,
             delete=delete, on_duplicate_key=on_duplicate_key)
 
+        self.ssh_client = None
         if ssh_config is not None:
             self.ssh_client = _ssh_client(ssh_config)
         if self.ssh_client is not None:
@@ -34,6 +35,10 @@ class SFTPStore(bs.BaseBlobStore):
         if sftp_client is not None:
             self.sftp_client = sftp_client
         else:
+            # This is to allow testing the importing/subpackage aspect without
+            # having to actually test the class by mocking an ssh connection.
+            if cachedir == None and basepath == None:
+                return
             raise ValueError('You must specify a SFTP client by passing in one of: sftp_client, ssh_config, ssh_client')
 
         self.cachedir = bs._abspath(cachedir)

--- a/tests/provenance/test_blobstores.py
+++ b/tests/provenance/test_blobstores.py
@@ -81,6 +81,19 @@ def test_s3store(s3fs):
 
     assert_store_basic_ops(store, key, obj)
 
+def test_sftpstore_import():
+    import provenance._config as c
+    try:
+        import paramiko
+        _paramiko = True
+    except ImportError:
+        _paramiko = False
+    try:
+        store = c.BLOBSTORE_TYPES['sftp'](cachedir=None, basepath=None)
+        assert(_paramiko == True)
+    except ImportError:
+        assert(_paramiko == False)
+
 def test_chained_storage_with_disk_and_s3_sharing_cachedir(s3fs):
     tmp_dir = '/tmp/prov_shared_store'
     shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
Sorry @bmabey, yet another bug from me. -1 for manual testing...

I wouldn't have thought that `e` goes out of scope there.