### PR TITLE
Change the default name from fn_name to fn_module.fn_name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+0.10.0 (TBD)
+------------
+
+* Change the default artifact name from the function name to the fully qualified module and function name.
+  This will invalidate previously cached artifacts unless the names are migrated or explicitly set.
+* Other changes that need to be aggregated before making the release
+
 0.9.4.2 (2016-03-23)
 ---------------------
 

--- a/provenance/core.py
+++ b/provenance/core.py
@@ -42,7 +42,8 @@ ArtifactRecord = namedtuple('ArtifactRecord', artifact_properties)
 def fn_info(f):
     info = utils.fn_info(f)
     metadata = get_metadata(f)
-    info['identifiers'] = {'name': metadata['name'],
+    name = metadata['name'] or '.'.join([info['module'], info['name']])
+    info['identifiers'] = {'name': name,
                            'version': metadata['version'],
                            'input_hash_fn': metadata['input_hash_fn']}
     info['input_process_fn'] = metadata['input_process_fn']
@@ -84,7 +85,7 @@ def fn_info(f):
 
     if not valid_serializer:
         msg = 'Invalid serializer option "{}" for artifact "{}", available serialziers: {} '.\
-              format(info['serializer'], info['name'], tuple(s.serializers.keys()))
+              format(info['serializer'], info['identifiers']['name'], tuple(s.serializers.keys()))
         raise ValueError(msg)
 
     return info
@@ -508,14 +509,11 @@ def provenance(version=0, repo=None, name=None, merge_defaults=None,
         input_process_fn = lambda inputs: inputs
 
     def wrapped(f):
-        _name = name
-        if _name is None:
-            _name = f.__name__
         _custom_fields = custom_fields or {}
         if tags:
             _custom_fields['tags'] = tags
         f._provenance_metadata = {'version': version,
-                                  'name': _name,
+                                  'name': name,
                                   'archive_file': archive_file,
                                   'delete_original_file': delete_original_file,
                                   'input_hash_fn': input_hash_fn,

--- a/tests/provenance/test_repos.py
+++ b/tests/provenance/test_repos.py
@@ -46,13 +46,13 @@ def test_inputs_json(db_session):
         "filename": "foo-bar",
         "timestamp": now,
         "inc_x": {
-            "id": "d2a4dd06f3193726cc2368d63de11c5792736467",
-            "name": "process_data_X",
+            "id": "2c33a362ebd51f830d0b245473ab6c1269674259",
+            "name": "test_repos.process_data_X",
             "type": "ArtifactProxy"
         },
         "inc_y": {
-            "id": "2816e9da806c5204820f0c45e79366dc42292fb4",
-            "name": "process_data_Y",
+            "id": "f9b1bb7a8aaf435fbf60b92cd88bf6c46604f702",
+            "name": "test_repos.process_data_Y",
             "type": "ArtifactProxy"
         }
     }


### PR DESCRIPTION
This pull-request breaks backwards compatibility for all provenanced functions that don't have an explicit name set. When this is merged, we definitely need to change the version number accordingly and probably should start a changelog with some notice of backwards incompatible changes.