### PR TITLE
use a dictionary of labels instead of a string for identifying sets

### DIFF
--- a/provenance/__init__.py
+++ b/provenance/__init__.py
@@ -8,10 +8,10 @@ from .core import (archive_file, ensure_proxies, promote, provenance,
 from .hashing import hash, value_repr
 from .repos import (capture_set, create_set, current_config,
                     get_check_mutations, get_default_repo, get_repo_by_name,
-                    load_set_by_id, load_set_by_name, get_use_cache, is_proxy,
-                    lazy_dict, lazy_proxy_dict, load_artifact, load_proxy,
-                    set_check_mutations, set_default_repo, set_run_info_fn,
-                    set_use_cache, using_repo)
+                    load_set_by_id, load_set_by_name, load_set_by_labels,
+                    get_use_cache, is_proxy, lazy_dict, lazy_proxy_dict,
+                    load_artifact, load_proxy, set_check_mutations,
+                    set_default_repo, set_run_info_fn, set_use_cache, using_repo)
 from .serializers import register_serializer
 
 __version__ = get_versions()['version']

--- a/provenance/core.py
+++ b/provenance/core.py
@@ -665,27 +665,27 @@ def archive_file(filename, name=None, delete_original=False, custom_fields=None,
     return _archive_file(filename, custom_fields)
 
 
-def provenance_set(set_name=None, initial_set=None, set_name_fn=None):
-    if set_name and set_name_fn:
-        raise ValueError("You cannot provide both set_name and set_name_fn.")
+def provenance_set(set_labels=None, initial_set=None, set_labels_fn=None):
+    if set_labels and set_labels_fn:
+        raise ValueError("You cannot provide both set_labels and set_labels_fn.")
 
     def make_wrapper(f):
-        if set_name_fn:
+        if set_labels_fn:
             base_fn = _base_fn(f)
             extract_args = utils.args_extractor(base_fn, merge_defaults=True)
             func_info = utils.fn_info(f)
 
         @bfu.wraps(f)
         def wrapper(*fargs, **fkargs):
-            if set_name_fn:
+            if set_labels_fn:
                 varargs, argsd = extract_args(fargs, fkargs)
                 varargs += func_info['varargs']
                 argsd.update(func_info['kargs'])
-                name = set_name_fn(*varargs, **argsd)
+                labels = set_labels_fn(*varargs, **argsd)
             else:
-                name = set_name
+                labels = set_labels
 
-            with repos.capture_set(name=name, initial_set=initial_set) as result:
+            with repos.capture_set(labels=labels, initial_set=initial_set) as result:
                 f(*fargs, **fkargs)
             return result[0]
 

--- a/provenance/models.py
+++ b/provenance/models.py
@@ -110,23 +110,26 @@ class ArtifactSet(Base):
 
     id = sa.Column(pg.INTEGER, primary_key=True)
     set_id = sa.Column(pg.VARCHAR(SHA1_LENGTH))
-    name = sa.Column(pg.VARCHAR(1000))
+    labels = sa.Column(pg.JSONB)
     created_at = sa.Column(pg.TIMESTAMP, default=datetime.utcnow)
 
 
     def __init__(self, artifact_set):
         self.set_id = artifact_set.id
-        self.name = artifact_set.name
+        labels = artifact_set.labels
+        if isinstance(artifact_set.labels, str):
+            labels = {'name': artifact_set.labels}
+        self.labels = labels
         self.created_at = artifact_set.created_at
 
     @memoized_property
     def props(self):
         return {'id': self.set_id,
-                'name': self.name,
+                'labels': self.labels,
                 'created_at': self.created_at}
 
     def __repr__(self):
-        return '<ArtifactSet %r, %r>' % (self.set_id, self.name)
+        return '<ArtifactSet %r, %r>' % (self.set_id, self.labels)
 
 
 class ArtifactSetMember(Base):

--- a/tests/provenance/test_repos.py
+++ b/tests/provenance/test_repos.py
@@ -112,7 +112,7 @@ def test_repo_set_put_and_finding(repo):
     repo.put_set(artifact_set)
 
     assert repo.get_set_by_id(artifact_set.id) == artifact_set
-    found_set = repo.get_set_by_name('foo')
+    found_set = repo.get_set_by_labels('foo')
     assert found_set.name == 'foo'
     assert found_set.artifact_ids == {'123'}
 
@@ -124,7 +124,7 @@ def test_repo_raises_key_error_when_set_id_not_found(repo):
 
 def test_repo_raises_key_error_when_set_name_not_found(repo):
     with pytest.raises(KeyError) as e:
-        repo.get_set_by_name('foo')
+        repo.get_set_by_labels('foo')
 
 
 def test_repo_contains_set(repo):


### PR DESCRIPTION
I'm not sure why we didn't think of this sooner. Instead of munging useful data into a string an artifact set now is identified by a label dictionary. This is a breaking API change but some convenience was added to still allow strings to be passed in and a `{'name': string_passed_in}` is used as the labels.

To see this and the related `provenance_set` decorator in action see the new tests:

https://github.com/bmabey/provenance/blob/set-labels/tests/provenance/test_core.py#L377-L386

https://github.com/bmabey/provenance/blob/set-labels/tests/provenance/test_core.py#L601-L617
