### PR TITLE
serialize pandas dataframes as parquet files by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install numpy
+  - conda install -c conda-forge pyarrow
   - pip install -r test_requirements.txt
   - python setup.py install
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - sphinx
 - pandoc
 - ipykernel
+- pyarrow
 # for the docs
 - scikit-learn
 - pip:

--- a/provenance/serializers.py
+++ b/provenance/serializers.py
@@ -1,38 +1,117 @@
 from collections import namedtuple
-import toolz as t
+from functools import singledispatch
+
 import cloudpickle
 import joblib
+import toolz as t
 
 from .hashing import hash
 
-def cloudpickle_dump(obj, filename, **kargs):
+
+def cloudpickle_dump(obj, filename, **kwargs):
     with open(filename, 'wb') as f:
-        return cloudpickle.dump(obj, f, **kargs)
+        return cloudpickle.dump(obj, f, **kwargs)
 
 
-def cloudpickle_load(filename, **kargs):
+def cloudpickle_load(filename, **kwargs):
     with open(filename, 'rb') as f:
-        return cloudpickle.load(f, **kargs)
+        return cloudpickle.load(f, **kwargs)
 
 
-Serializer = namedtuple('Serializer', 'name, dump, load')
+Serializer = namedtuple('Serializer', 'name, dump, load, content_type, content_encoding, content_disposition')
 
 
-serializers = {'joblib': Serializer('joblib', joblib.dump, joblib.load),
-               'cloudpickle': Serializer('cloudpickle',
-                                         cloudpickle_dump,
-                                         cloudpickle_load),}
+def joblib_dump(obj, filename, compress=2, **kwargs):
+    joblib.dump(obj, filename, compress=compress, **kwargs)
 
 
-def register_serializer(name, dump, load):
-    serializers[name] = Serializer(name, dump, load)
+serializers = {}
+
+
+@singledispatch
+def object_serializer(obj):
+    """
+    Takes an object and returns the appropirate serializer name, dump, and load arguments.
+
+    Parameters
+    ----------
+    obj : any python object or primitive
+
+    Returns
+    -------
+    tuple of serializer name (str), dump args (dictionary), load args (dictionary)
+    """
+    return DEFAULT_VALUE_SERIALIZER.name
+
+
+def register_serializer(name, dump, load, content_type=None,
+                        content_encoding=None, content_disposition=None,
+                        classes=None):
+    serializers[name] = Serializer(name, dump, load,
+                                    content_type,
+                                    content_encoding,
+                                    content_disposition)
+    if classes is None:
+        return
+    for cls in classes:
+        object_serializer.register(cls, lambda _: name)
+
+
+register_serializer("joblib", joblib_dump, joblib.load)
+register_serializer("cloudpickle", cloudpickle_dump, cloudpickle_load)
+
+
+def _pandas_and_parquet_present():
+    try:
+        import pandas
+    except ImportError:
+        return False
+    try:
+        import pyarrow
+    except:
+        try:
+            import fastparquet
+        except ImportError:
+            return False
+    return True
+
+if _pandas_and_parquet_present():
+    import pandas as pd
+
+    def pd_df_parquet_dump(df, filename, **kwargs):
+        return df.to_parquet(filename, **kwargs)
+
+    def pd_df_parquet_load(filename, **kwargs):
+        return pd.read_parquet(filename, **kwargs)
+
+    register_serializer('pd_df_parquet', pd_df_parquet_dump, pd_df_parquet_load,
+                        classes=[pd.DataFrame])
+
+
+    def pd_series_parquet_dump(series, filename, **kwargs):
+        if series.name is None:
+            # pyarrow requires the column names be strings
+            series = pd.Series(series, name='_series')
+        return pd.DataFrame(series).to_parquet(filename, **kwargs)
+
+    def pd_series_parquet_load(filename, **kwargs):
+        series = pd.read_parquet(filename, **kwargs).ix[:,0]
+        if series.name == "_series":
+            series.name = None
+        return series
+
+
+    register_serializer('pd_series_parquet', pd_series_parquet_dump, pd_series_parquet_load,
+                        classes=[pd.Series])
+
 
 @t.memoize(key=lambda *args: hash(args))
 def partial_serializer(serializer_name, dump_kwargs, load_kwargs):
     s = serializers[serializer_name]
     return Serializer(s.name,
                       t.partial(s.dump, **dump_kwargs) if dump_kwargs else s.dump,
-                      t.partial(s.load, **load_kwargs) if load_kwargs else s.load)
+                      t.partial(s.load, **load_kwargs) if load_kwargs else s.load,
+                      s.content_type, s.content_encoding, s.content_disposition)
 
 
 def serializer(artifact):

--- a/provenance/test_serializers.py
+++ b/provenance/test_serializers.py
@@ -1,0 +1,15 @@
+import toolz as t
+import pytest
+import pandas as pd
+import provenance.serializers as s
+
+def test_default_object_serializers():
+    assert s.object_serializer('foo') == 'joblib'
+    assert s.object_serializer((1,2,3)) == 'joblib'
+    assert s.object_serializer({'foo': 42}) == 'joblib'
+
+    df = pd.DataFrame([{"foo": 42}, {"foo": 55}])
+    assert s.object_serializer(df) == 'pd_df_parquet'
+
+    series = df.foo
+    assert s.object_serializer(series) == 'pd_series_parquet'


### PR DESCRIPTION
With these changes it is possible to register serializers that are automatically chosen based on the return type.

The motivation was that it is better to store panda dataframes (and series) as Parquet files. Since this is a sane default this serializer is shipping with the library but only is registered if the needed deps are present.