### PR TITLE
Adding `__reduce_ex__` and `__copy__` methods for the `ObjectProxy` subclasses...

### DIFF
--- a/provenance/repos.py
+++ b/provenance/repos.py
@@ -326,8 +326,8 @@ class ArtifactProxy(wrapt.ObjectProxy, Proxy):
     def __copy__(self):
         return ArtifactProxy(copy.copy(self.__wrapped__), self._self_artifact)
 
-    def __deepcopy__(self):
-        return ArtifactProxy(copy.deepcopy(self.__wrapped__), self._self_artifact)
+    def __deepcopy__(self, memo=None):
+        return ArtifactProxy(copy.deepcopy(self.__wrapped__, memo), self._self_artifact)
 
 
 class CallableArtifactProxy(wrapt.CallableObjectProxy, Proxy):
@@ -352,8 +352,8 @@ class CallableArtifactProxy(wrapt.CallableObjectProxy, Proxy):
     def __copy__(self):
         return CallableArtifactProxy(copy.copy(self.__wrapped__), self._self_artifact)
 
-    def __deepcopy__(self):
-        return CallableArtifactProxy(copy.deepcopy(self.__wrapped__), self._self_artifact)
+    def __deepcopy__(self, memo=None):
+        return CallableArtifactProxy(copy.deepcopy(self.__wrapped__, memo), self._self_artifact)
 
 def artifact_proxy(value, artifact):
     if callable(value):

--- a/provenance/repos.py
+++ b/provenance/repos.py
@@ -324,7 +324,10 @@ class ArtifactProxy(wrapt.ObjectProxy, Proxy):
         return self.__reduce__()
 
     def __copy__(self):
-        return ArtifactProxy(self.__wrapped__, self._self_artifact)
+        return ArtifactProxy(copy.copy(self.__wrapped__), self._self_artifact)
+
+    def __deepcopy__(self):
+        return ArtifactProxy(copy.deepcopy(self.__wrapped__), self._self_artifact)
 
 
 class CallableArtifactProxy(wrapt.CallableObjectProxy, Proxy):
@@ -347,8 +350,10 @@ class CallableArtifactProxy(wrapt.CallableObjectProxy, Proxy):
         return self.__reduce__()
 
     def __copy__(self):
-        return CallableArtifactProxy(self.__wrapped__, self._self_artifact)
+        return CallableArtifactProxy(copy.copy(self.__wrapped__), self._self_artifact)
 
+    def __deepcopy__(self):
+        return CallableArtifactProxy(copy.deepcopy(self.__wrapped__), self._self_artifact)
 
 def artifact_proxy(value, artifact):
     if callable(value):

--- a/provenance/repos.py
+++ b/provenance/repos.py
@@ -318,7 +318,13 @@ class ArtifactProxy(wrapt.ObjectProxy, Proxy):
             format(self.artifact.id, repr(self.__wrapped__))
 
     def __reduce__(self):
-        return (load_proxy , (self.artifact.id,))
+        return (load_proxy, (self.artifact.id,))
+
+    def __reduce_ex__(self, protocol_version):
+        return self.__reduce__()
+
+    def __copy__(self):
+        return ArtifactProxy(self.__wrapped__, self._self_artifact)
 
 
 class CallableArtifactProxy(wrapt.CallableObjectProxy, Proxy):
@@ -336,6 +342,12 @@ class CallableArtifactProxy(wrapt.CallableObjectProxy, Proxy):
 
     def __reduce__(self):
         return (load_proxy, (self.artifact.id,))
+
+    def __reduce_ex__(self, protocol_version):
+        return self.__reduce__()
+
+    def __copy__(self):
+        return CallableArtifactProxy(self.__wrapped__, self._self_artifact)
 
 
 def artifact_proxy(value, artifact):

--- a/tests/provenance/test_repos.py
+++ b/tests/provenance/test_repos.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import copy
 
 import pandas as pd
 import pytest
@@ -103,6 +104,20 @@ def test_basic_repo_ops(repo):
 
     with pytest.raises(KeyError) as e:
         repo.get_by_value_id(artifact.id)
+
+
+@pytest.mark.parametrize('artifact_class', [r.ArtifactProxy, r.CallableArtifactProxy])
+@pytest.mark.parametrize('copy_method', [copy.copy, copy.deepcopy])
+def test_copy_Proxies(repo, artifact_class, copy_method):
+    class Artifact():
+        def __init__(self, id):
+            self.id = id
+
+    a = artifact_class({'a': 1, 'b': 2, 'c': 3}, Artifact('1'))
+    b = copy_method(a)
+    b['a'] = 10
+
+    assert a['a'] != b['a']
 
 
 def test_repo_set_put_and_finding(repo):


### PR DESCRIPTION
Adding `__reduce_ex__` and `__copy__` methods for the `ObjectProxy` subclasses in order to modernize the version of `wrapt` used.

This should be the minimal changes suggested by the discussion in the related issue. Locally, I see a reduction of failures from:

```35 failed, 180 passed in 22.42 seconds```

to

```20 failed, 195 passed in 16.30 seconds```

Closes #52.