### PR TITLE
Added angled bracket escaping to `elide`

### DIFF
--- a/provenance/vis/utils.py
+++ b/provenance/vis/utils.py
@@ -7,7 +7,7 @@ from ..repos import is_proxy
 
 
 def elide(obj, length=30):
-    table = str.maketrans({"{": "\{", "}": "\}"})
+    table = str.maketrans({"{": "\{", "}": "\}", "<": "\<", ">": "\>"})
     s = str(obj).translate(table)
     return (s[:length] + '..') if len(s) > length else s
 


### PR DESCRIPTION
Tests all pass, just adds escaping of angled brackets (`<` and `>`), which is necessary for visualizing some lineages.