### PR TITLE
Remove deprecated joblib module imports

### DIFF
--- a/provenance/_dependencies.py
+++ b/provenance/_dependencies.py
@@ -1,6 +1,5 @@
 import cloudpickle
 import io
-from joblib._compat import _bytes_or_unicode, PY3_OR_LATER
 from ordered_set import OrderedSet
 import pickle
 
@@ -16,8 +15,7 @@ class DependencyWalker(Pickler):
         self.stream = io.BytesIO()
         self.dependents = []
         self.branches = []
-        protocol = (pickle.DEFAULT_PROTOCOL if PY3_OR_LATER
-                    else pickle.HIGHEST_PROTOCOL)
+        protocol = pickle.DEFAULT_PROTOCOL
         Pickler.__init__(self, self.stream, protocol=protocol)
 
     def save(self, obj):

--- a/provenance/hashing.py
+++ b/provenance/hashing.py
@@ -24,9 +24,6 @@ import struct
 import io
 import decimal
 
-from joblib._compat import _bytes_or_unicode, PY3_OR_LATER
-
-
 
 @singledispatch
 def value_repr(obj):
@@ -74,8 +71,7 @@ class Hasher(Pickler):
         self.stream = io.BytesIO()
         # By default we want a pickle protocol that only changes with
         # the major python version and not the minor one
-        protocol = (pickle.DEFAULT_PROTOCOL if PY3_OR_LATER
-                    else pickle.HIGHEST_PROTOCOL)
+        protocol = pickle.DEFAULT_PROTOCOL
         Pickler.__init__(self, self.stream, protocol=protocol)
         # Initialise the hash obj
         self._hash = hashlib.new(hash_name)

--- a/provenance/utils.py
+++ b/provenance/utils.py
@@ -1,8 +1,8 @@
+import inspect
 from collections import OrderedDict, Sequence
 import toolz as t
 import toolz.curried as tc
 from boltons import funcutils as bfu
-from joblib.func_inspect import getfullargspec
 
 from provenance.compatibility import getargspec
 
@@ -18,7 +18,7 @@ def args_extractor(f, merge_defaults=False):
     have a names.
 
     """
-    spec = getfullargspec(f)
+    spec = inspect.getfullargspec(f)
     if spec.defaults:
         param_defaults = dict(zip(spec.args[-len(spec.defaults):],
                                    spec.defaults))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 s3fs==0.0.9
 boltons>=16.5.1
-joblib>=0.10.2
+joblib>=0.14.2
 toolz>=0.8.2
 cloudpickle>=0.2.1
 psutil>=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 s3fs==0.0.9
 boltons>=16.5.1
-joblib>=0.14.2
+joblib>=0.15.0
 toolz>=0.8.2
 cloudpickle>=0.2.1
 psutil>=5.0.0


### PR DESCRIPTION
Fixes #60 

This PR removes `_bytes_or_unicode, PY3_OR_LATER` import from `joblib._compat` and `getfullargspec` import from `joblib.func_inspect`. These imports were deprecated as of joblib v0.15.0 or later. Additionaly, the version of `joblib` pinned in `requirements.txt` is update to `0.15.0` or later. Please let me know if it is worth maintaining backwards compatibility with joblib versions before `0.15.0`. 

