### PR TITLE
Remove unnecessary setup requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ install:
   - pip install python-dateutil==2.8.0
   - python setup.py install
 
-script: python setup.py test
+script: pytest -v 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     packages=['provenance', 'provenance.sftp', 'provenance.vis'],
-    setup_requires=['pytest>=3.0.0', 'pytest-runner'],
     install_requires=[open('requirements.txt').read().strip().split('\n')],
     tests_requires=[open('test_requirements.txt').read().strip().split('\n')],
     extras_require=subpackages,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     packages=['provenance', 'provenance.sftp', 'provenance.vis'],
     install_requires=[open('requirements.txt').read().strip().split('\n')],
-    tests_requires=[open('test_requirements.txt').read().strip().split('\n')],
     extras_require=subpackages,
     include_package_data=True,
     description="Provenance and caching library for functions, built for creating lightweight machine learning pipelines.",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,3 +7,4 @@ hypothesis>=3.6.0
 h5py
 pandas
 torch
+-r requirements.txt

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,4 +7,3 @@ hypothesis>=3.6.0
 h5py
 pandas
 torch
--r requirements.txt

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
 moto>=0.4.30
-pytest==3.6
+pytest>=3.0.0
+pytest-runner
 pytest-pythonpath>=0.7.1
 # remove hypothesis if we don't end up writing property tests with it
 hypothesis>=3.6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 moto>=0.4.30
-pytest>=3.0.0
+pytest==3.6
 pytest-runner
 pytest-pythonpath>=0.7.1
 # remove hypothesis if we don't end up writing property tests with it


### PR DESCRIPTION
I realize that some unnecessary requirements were defined in `setup.py`: `setup_requires=['pytest>=3.0.0', 'pytest-runner']`. This PR removes these requirements. 

