### PR TITLE
Update linting CI GH action

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: "*"
   pull_request:
-    branches: master
+    branches: trunk
 
 jobs:
 

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -7,37 +7,14 @@ on:
     branches: trunk
 
 jobs:
-
-  lint-yapf:
-    name: yapf-formatter
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Install yapf
-        run: |
-          python -m pip install yapf
-      - name: yapf Code Formatter
-        run: |
-          yapf --diff --recursive --parallel .
-
-  lint-isort:
-    name: isort
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install isort
-        run: |
-          python -m pip install isort
-      - name: isort check
-        run: |
-          isort --recursive --check-only .
+      - name: Lint via pre-commit checks
+        uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v3.1.0
+      rev: v3.3.0
       hooks:
       -   id: trailing-whitespace
       -   id: end-of-file-fixer
@@ -21,6 +21,6 @@ repos:
       hooks:
       -   id: seed-isort-config
   -   repo: https://github.com/pre-commit/mirrors-isort
-      rev: v4.3.21
+      rev: v5.6.4
       hooks:
       -   id: isort

--- a/provenance/serializers.py
+++ b/provenance/serializers.py
@@ -71,14 +71,14 @@ register_serializer('cloudpickle', cloudpickle_dump, cloudpickle_load)
 
 def _pandas_and_parquet_present():
     try:
-        import pandas    # noqa: F401
+        import pandas
     except ImportError:
         return False
     try:
-        import pyarrow    # noqa: F401
+        import pyarrow
     except:
         try:
-            import fastparquet    # noqa: F401
+            import fastparquet
         except ImportError:
             return False
     return True
@@ -119,7 +119,7 @@ if _pandas_and_parquet_present():
 
 def _pytorch_present():
     try:
-        import torch    # noqa F401
+        import torch
     except:
         return False
     return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ split_before_named_assigns = true
 
 
 [isort]
-known_first_party=intake_esm
+known_first_party=provenance
 known_third_party=alembic,boltons,cloudpickle,conftest,frozendict,google,graphviz,hypothesis,joblib,memoized_property,numpy,pandas,paramiko,psutil,pytest,s3fs,setuptools,sqlalchemy,sqlalchemy_utils,strategies,toolz,wrapt
 multi_line_output=3
 include_trailing_comma=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ parentdir_prefix = provenance-
 
 [flake8]
 exclude = docs
-ignore = E203,E266,E501,W503,E722,E402,C901,E731
+ignore = E203,E266,E501,W503,E722,E402,C901,E731,F401
 max-line-length = 100
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/tests/provenance/conftest.py
+++ b/tests/provenance/conftest.py
@@ -23,8 +23,8 @@ def s3fs():
 
     m = moto.mock_s3()
     m.start()
-    import s3fs
     import boto3
+    import s3fs
 
     client = boto3.client('s3')
     client.create_bucket(Bucket='bucket')

--- a/tests/provenance/test_blobstores.py
+++ b/tests/provenance/test_blobstores.py
@@ -87,7 +87,7 @@ def test_sftpstore_import():
     import provenance._config as c
 
     try:
-        import paramiko    # noqa: F401
+        import paramiko
 
         _paramiko = True
     except ImportError:

--- a/versioneer.py
+++ b/versioneer.py
@@ -1634,9 +1634,9 @@ def get_cmdclass():
 
     if 'py2exe' in sys.modules:    # py2exe enabled?
         try:
-            from py2exe.distutils_buildexe import py2exe as _py2exe    # py3
+            from py2exe.distutils_buildexe import py2exe as _py2exe  # py3
         except ImportError:
-            from py2exe.build_exe import py2exe as _py2exe    # py2
+            from py2exe.build_exe import py2exe as _py2exe  # py2
 
         class cmd_py2exe(_py2exe):
             def run(self):


### PR DESCRIPTION
- This PR attempts to fix the most recent CI failures due to `isort` by updating the isort version to 5.+ which includes breaking changes that are not present in prior versions. See https://github.com/bmabey/provenance/runs/1293535232 for more details


- This PR replaces existing yapf, isort checks with pre-commit GitHub action checks. This action guarantees that the environment used locally by the committer is the same as the one used in the CI.
