### PR TITLE
Relax s3fs minimum version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-s3fs==0.0.9
+s3fs>=0.0.9
 boltons>=16.5.1
 joblib>=0.15.0
 toolz>=0.8.2

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
     ],
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
It appears that most recent versions of `s3fs` require `aiohttp` which supports Python  3.6+ only. 

@bmabey, are you okay with making `provenance` Python 3.6+ compatible only?