### PR TITLE
Loosen s3fs requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-s3fs==0.0.9
+s3fs>=0.0.9
 boltons>=16.5.1
 joblib>=0.15.0
 toolz>=0.8.2


### PR DESCRIPTION
I would like to use `provenance` in a conda environment that is depending on some `s3fs` features introduced after `0.0.9`